### PR TITLE
Pyocd has now been changed to probe-rs-cli

### DIFF
--- a/rustBoot/src/image/image.rs
+++ b/rustBoot/src/image/image.rs
@@ -20,8 +20,8 @@ use sha2::Sha256;
 use sha2::Sha384;
 // use sha2::digest::{Digest};
 
+use core::cell::OnceCell;
 use core::convert::TryInto;
-use core::lazy::OnceCell;
 
 /// Singleton to ensure we only ever have one instance of the `BOOT` partition
 static mut BOOT: OnceCell<PartDescriptor<Boot>> = OnceCell::new();

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,8 +11,8 @@ rustBoot = {path = "../rustBoot"}
 xshell = "0.1.9"
 
 [features]
-nrf52840 = ["rustBoot/nrf52840"]
-stm32f411 = ["rustBoot/stm32f411"]
-stm32f446 = ["rustBoot/stm32f446"]
-stm32h723 = ["rustBoot/stm32h723"]
+nrf52840 = ["mcu", "rustBoot/nrf52840"]
+stm32f411 = ["mcu", "rustBoot/stm32f411"]
+stm32f446 = ["mcu", "rustBoot/stm32f446"]
+stm32h723 = ["mcu", "rustBoot/stm32h723"]
 mcu = []

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -68,6 +68,7 @@ fn build_rustBoot_only(target: &&str) -> Result<(), anyhow::Error> {
         &"stm32h723" => {
             cmd!("cargo build --release").run()?;
         }
+
         _ => {
             println!("board not supported");
         }
@@ -99,9 +100,9 @@ fn sign_packages(target: &&str) -> Result<(), anyhow::Error> {
     match *target {
         "nrf52840" => {
             let _p = xshell::pushd(root_dir().join("boards/rbSigner/signed_images"))?;
-            cmd!("py convert2bin.py").run()?;
+            cmd!("python3 convert2bin.py").run()?;
             // python script has a linux dependency - `wolfcrypt`
-            cmd!("wsl python3 signer.py").run()?;
+            cmd!("python3 signer.py").run()?;
             Ok(())
         }
         "stm32f411" => {
@@ -128,6 +129,7 @@ fn sign_packages(target: &&str) -> Result<(), anyhow::Error> {
             cmd!("python3 signer.py").run()?;
             Ok(())
         }
+
         _ => todo!(),
     }
 }
@@ -138,43 +140,40 @@ fn flash_signed_fwimages(target: &&str) -> Result<(), anyhow::Error> {
         "nrf52840" => {
             let _p = xshell::pushd(root_dir().join("boards/rbSigner/signed_images"))?;
             let boot_part_addr = format!("0x{:x}", BOOT_PARTITION_ADDRESS);
-            cmd!("pyocd flash -t nrf52840 --base-address {boot_part_addr} nrf52840_bootfw_v1234_signed.bin").run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {boot_part_addr} --chip nRF52840_xxAA nrf52840_bootfw_v1234_signed.bin").run()?;
 
             let updt_part_addr = format!("0x{:x}", UPDATE_PARTITION_ADDRESS);
-            cmd!("pyocd flash -t nrf52840 --base-address {updt_part_addr} nrf52840_updtfw_v1235_signed.bin").run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {updt_part_addr} --chip nRF52840_xxAA nrf52840_updtfw_v1235_signed.bin").run()?;
             Ok(())
         }
         "stm32f411" => {
             let _p = xshell::pushd(root_dir().join("boards/rbSigner/signed_images"))?;
             let boot_part_addr = format!("0x{:x}", BOOT_PARTITION_ADDRESS);
-            cmd!("pyocd flash --base-address {boot_part_addr} stm32f411_bootfw_v1235_signed.bin")
-                .run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {boot_part_addr} --chip stm32f411vetx stm32f411_bootfw_v1235_signed.bin").run()?;
 
             let updt_part_addr = format!("0x{:x}", UPDATE_PARTITION_ADDRESS);
-            cmd!("pyocd flash -t stm32f411 --base-address {updt_part_addr} stm32f411_updtfw_v1235_signed.bin").run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {updt_part_addr} --chip stm32f411vetx stm32f411_updtfw_v1235_signed.bin").run()?;
             Ok(())
         }
         "stm32f446" => {
             let _p = xshell::pushd(root_dir().join("boards/rbSigner/signed_images"))?;
             let boot_part_addr = format!("0x{:x}", BOOT_PARTITION_ADDRESS);
-            cmd!("pyocd flash --base-address {boot_part_addr} stm32f446_bootfw_v1235_signed.bin")
-                .run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {boot_part_addr} --chip stm32f446retx stm32f446_bootfw_v1235_signed.bin").run()?;
 
             let updt_part_addr = format!("0x{:x}", UPDATE_PARTITION_ADDRESS);
-            cmd!("pyocd flash -t stm32f446 --base-address {updt_part_addr} stm32f446_updtfw_v1235_signed.bin").run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {updt_part_addr} --chip stm32f446retx stm32f446_updtfw_v1235_signed.bin").run()?;
             Ok(())
         }
-
         "stm32h723" => {
             let _p = xshell::pushd(root_dir().join("boards/rbSigner/signed_images"))?;
             let boot_part_addr = format!("0x{:x}", BOOT_PARTITION_ADDRESS);
-            cmd!("pyocd flash --base-address {boot_part_addr} stm32f446_bootfw_v1235_signed.bin")
-                .run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {boot_part_addr} --chip STM32H723ZGIx stm32h723_bootfw_v1235_signed.bin").run()?;
 
             let updt_part_addr = format!("0x{:x}", UPDATE_PARTITION_ADDRESS);
-            cmd!("pyocd flash -t stm32f446 --base-address {updt_part_addr} stm32f446_updtfw_v1235_signed.bin").run()?;
+            cmd!("probe-rs-cli download --format Bin --base-address {updt_part_addr} --chip STM32H723ZGIx stm32h723_updtfw_v1235_signed.bin").run()?;
             Ok(())
         }
+
         _ => todo!(),
     }
 }
@@ -198,21 +197,52 @@ fn flash_rustBoot(target: &&str) -> Result<(), anyhow::Error> {
         }
         "stm32h723" => {
             let _p = xshell::pushd(root_dir().join("boards/bootloaders").join(target))?;
-            cmd!("cargo flash --chip stm32f446vetx --release").run()?;
+            cmd!("cargo flash --chip stm32h723ZGTx --release").run()?;
             Ok(())
         }
+
         _ => todo!(),
     }
 }
 
 #[cfg(feature = "mcu")]
 fn full_image_flash(target: &&str) -> Result<(), anyhow::Error> {
-    build_rustBoot(target)?;
-    sign_packages(target)?;
-    cmd!("pyocd erase -t nrf52 --mass-erase").run()?;
-    flash_signed_fwimages(target)?;
-    flash_rustBoot(target)?;
-    Ok(())
+    match *target {
+        "nrf52840" => {
+            build_rustBoot(target)?;
+            sign_packages(target)?;
+            cmd!("probe-rs-cli erase --chip nRF52840_xxAA").run()?;
+            flash_signed_fwimages(target)?;
+            flash_rustBoot(target)?;
+            Ok(())
+        }
+        "stm32f411" => {
+            build_rustBoot(target)?;
+            sign_packages(target)?;
+            cmd!("probe-rs-cli erase --chip stm32f411vetx").run()?;
+            flash_signed_fwimages(target)?;
+            flash_rustBoot(target)?;
+            Ok(())
+        }
+        "stm32f446" => {
+            build_rustBoot(target)?;
+            sign_packages(target)?;
+            cmd!("probe-rs-cli erase --chip stm32f446retx").run()?;
+            flash_signed_fwimages(target)?;
+            flash_rustBoot(target)?;
+            Ok(())
+        }
+        "stm32h723" => {
+            build_rustBoot(target)?;
+            sign_packages(target)?;
+            cmd!("probe-rs-cli erase --chip stm32h723ZGTx").run()?;
+            flash_signed_fwimages(target)?;
+            flash_rustBoot(target)?;
+            Ok(())
+        }
+
+        _ => todo!(),
+    }
 }
 
 fn root_dir() -> PathBuf {
@@ -276,19 +306,20 @@ fn erase_and_flash_trailer_magic(target: &&str) -> Result<(), anyhow::Error> {
         "stm32h723" => {
             let _p = xshell::pushd(root_dir().join("boards/rbSigner/signed_images"))?;
             // just to ensure that an existing bootloader doesnt start to boot automatically - during a test
-            cmd!("pyocd erase -t stm32f446 -s 0x0").run()?;
+            cmd!("pyocd erase -t stm32h723 -s 0x0").run()?;
             let boot_trailer_magic = format!("0x{:x}", BOOT_PARTITION_ADDRESS + PARTITION_SIZE - 4);
-            cmd!("pyocd erase -t stm32f446 -s {boot_trailer_magic}").run()?;
-            cmd!("pyocd flash -t stm32f446 --base-address {boot_trailer_magic} trailer_magic.bin")
+            cmd!("pyocd erase -t stm32h723 -s {boot_trailer_magic}").run()?;
+            cmd!("pyocd flash -t stm32h723 --base-address {boot_trailer_magic} trailer_magic.bin")
                 .run()?;
 
             let updt_trailer_magic =
                 format!("0x{:x}", UPDATE_PARTITION_ADDRESS + PARTITION_SIZE - 4);
-            cmd!("pyocd erase -t stm32f446 -s {updt_trailer_magic}").run()?;
-            cmd!("pyocd flash -t stm32f446 --base-address {updt_trailer_magic} trailer_magic.bin")
+            cmd!("pyocd erase -t stm32h723 -s {updt_trailer_magic}").run()?;
+            cmd!("pyocd flash -t stm32h723 --base-address {updt_trailer_magic} trailer_magic.bin")
                 .run()?;
             Ok(())
         }
+
         _ => todo!(),
     }
 }


### PR DESCRIPTION
Pyocd has now been changed to probe-rs-cli to flash secure boot and update firmware and tested on stm32h723 board. 

Here's the command line output.

```Terminal
imran@ubuntu:~/Desktop/rustBoot$ cargo stm32h723 build-sign-flash rustBoot
Compiling typenum v1.15.0
Compiling version_check v0.9.4
..
..
Compiling rustBoot v0.1.0 (/home/imran/Desktop/rustBoot/rustBoot)
Compiling xtask v0.1.0 (/home/imran/Desktop/rustBoot/xtask)
Finished dev [unoptimized + debuginfo] target(s) in 7.43s
Running target/debug/xtask stm32h723 build-sign-flash rustBoot
$ cargo build --release
Compiling version_check v0.9.4
Compiling typenum v1.15.0
..
..
Compiling rustBoot-hal v0.1.0 (/home/imran/Desktop/rustBoot/boards/hal)
Compiling rustBoot-update v0.1.0 (/home/imran/Desktop/rustBoot/boards/update)
Finished release [optimized] target(s) in 26.19s
$ cargo build --release
Compiling stm32h723_updtfw v0.1.0 (/home/imran/Desktop/rustBoot/boards/firmware/stm32h723/updt_fw_blinky_red)
Finished release [optimized] target(s) in 1.03s
$ cargo build --release
Compiling stm32h723 v0.1.0 (/home/imran/Desktop/rustBoot/boards/bootloaders/stm32h723)
Finished release [optimized] target(s) in 1.50s
$ python3 convert2bin.py
$ python3 signer.py
['sign.py', '--ecc256', '--sha256', 'stm32h723_bootfw.bin', 'ecc256.der', '1234']
Update type:          Firmware
Input image:          stm32h723_bootfw.bin
Selected cipher:      ecc256
Public key:           ecc256.der
Output image:         stm32h723_bootfw_v1234_signed.bin
Not Encrypted
Calculating sha256 digest...
Signing the firmware...
Done.
Output image successfully created.
['sign.py', '--ecc256', '--sha256', 'stm32h723_updtfw.bin', 'ecc256.der', '1235']
Update type:          Firmware
Input image:          stm32h723_updtfw.bin
Selected cipher:      ecc256
Public key:           ecc256.der
Output image:         stm32h723_updtfw_v1235_signed.bin
Not Encrypted
Calculating sha256 digest...
Signing the firmware...
Done.
Output image successfully created.
$ probe-rs-cli erase --chip stm32h723zgtx
$ probe-rs-cli download --format Bin --base-address 0x8020000 --chip stm32h723zgtx stm32h723_bootfw_v1234_signed.bin
Erasing sectors ✔ [00:00:00] [##################################################################################################]  3.00KiB/ 3.00KiB @  7.30KiB/s (eta 0s )
Programming pages   ✔ [00:00:00] [##################################################################################################]  3.00KiB/ 3.00KiB @  3.85KiB/s (eta 0s )
Finished in 0.611s
$ probe-rs-cli download --format Bin --base-address 0x8060000 --chip stm32h723zgtx stm32h723_updtfw_v1235_signed.bin
Erasing sectors ✔ [00:00:00] [##################################################################################################]  3.00KiB/ 3.00KiB @  7.17KiB/s (eta 0s )
Programming pages   ✔ [00:00:00] [##################################################################################################]  3.00KiB/ 3.00KiB @  3.77KiB/s (eta 0s )
Finished in 0.613s
$ cargo flash --chip stm32h723zgtx --release
Finished release [optimized] target(s) in 0.04s
Flashing /home/imran/Desktop/rustBoot/boards/target/thumbv7em-none-eabihf/release/stm32h723
Erasing sectors ✔ [00:00:02] [##################################################################################################] 47.00KiB/47.00KiB @ 17.60KiB/s (eta 0s )
Programming pages   ✔ [00:00:03] [##################################################################################################] 47.00KiB/47.00KiB @  7.60KiB/s (eta 0s )
Finished in 5.773s

imran@ubuntu:~/Desktop/rustBoot$ probe-rs-cli dump --chip stm32h723zgtx 0x08020000 3
Addr 0x08020000: 0x54535552
Addr 0x08020004: 0x00000980
Addr 0x08020008: 0x00040001
Read 3 words in 4.666941ms


imran@ubuntu:~/Desktop/rustBoot$ hexdump -C -n8 boards/rbSigner/signed_images/stm32h723_bootfw_v1234_signed.bin
00000000  52 55 53 54 80 09 00 00                           |RUST....|
00000008
```