### PR TITLE
Test case added for "digest_tag_len", Made changes in stm32f334 flash driver indentation and Xtask

### DIFF
--- a/boards/hal/src/stm/stm32f334.rs
+++ b/boards/hal/src/stm/stm32f334.rs
@@ -49,48 +49,16 @@ impl FlashInterface for FlashWriterEraser {
     /// -  NONE
     fn hal_flash_erase(&self, addr: usize, len: usize) {
         let mut flag: bool = true;
-        let mut address = (addr & 0x0800_F800) as u32;
+        let mut address = (addr & 0x0800_F800) as u32; // Finding base address of the page from the given address 
         let remaing_bytes  = len%FLASH_PAGE_SIZE as usize;
         let mut num_pages = len/FLASH_PAGE_SIZE as usize;
         if remaing_bytes != 0
         {
            num_pages = num_pages + 1; 
         }
-    
         while num_pages > 0 {
             match address {
-                (0x0800_0000..=0x0800_07FF) => flag = true,
-                (0x0800_0800..=0x0800_0FFF) => flag = true,
-                (0x0800_1000..=0x0800_17FF) => flag = true,
-                (0x0800_1800..=0x0800_1FFF) => flag = true,
-                (0x0800_2000..=0x0800_27FF) => flag = true,
-                (0x0800_2800..=0x0800_2FFF) => flag = true,
-                (0x0800_3000..=0x0800_37FF) => flag = true,
-                (0x0800_3800..=0x0800_3FFF) => flag = true,
-                (0x0800_4000..=0x0800_47FF) => flag = true,
-                (0x0800_4800..=0x0800_4FFF) => flag = true,
-                (0x0800_5000..=0x0800_57FF) => flag = true,
-                (0x0800_5800..=0x0800_5FFF) => flag = true,
-                (0x0800_6000..=0x0800_67FF) => flag = true,
-                (0x0800_6800..=0x0800_6FFF) => flag = true,
-                (0x0800_7000..=0x0800_77FF) => flag = true,
-                (0x0800_7800..=0x0800_7FFF) => flag = true,
-                (0x0800_8000..=0x0800_87FF) => flag = true,
-                (0x0800_8800..=0x0800_8FFF) => flag = true,
-                (0x0800_9000..=0x0800_97FF) => flag = true,
-                (0x0800_9800..=0x0800_9FFF) => flag = true,
-                (0x0800_A000..=0x0800_A7FF) => flag = true,
-                (0x0800_A800..=0x0800_AFFF) => flag = true, 
-                (0x0800_B000..=0x0800_B7FF) => flag = true,
-                (0x0800_B800..=0x0800_BFFF) => flag = true,
-                (0x0800_C000..=0x0800_C7FF) => flag = true,
-                (0x0800_C800..=0x0800_CFFF) => flag = true,
-                (0x0800_D000..=0x0800_D7FF) => flag = true,
-                (0x0800_D800..=0x0800_DFFF) => flag = true,
-                (0x0800_E000..=0x0800_E7FF) => flag = true,
-                (0x0800_E800..=0x0800_EFFF) => flag = true,
-                (0x0800_F000..=0x0800_F7FF) => flag = true,
-                (0x0800_F800..=0x0800_FFFF) => flag = true,
+                (0x0800_0000..=0x0800_FFFF) => flag = true,
                 _ => flag = false,
             }
             if flag {
@@ -178,29 +146,29 @@ impl FlashInterface for FlashWriterEraser {
                 let  src1 = src as *mut u8;
                 let mut data1 = 0; 
                 let mut add = 0u16;
-                let mut c = 0usize;                            
+                let mut half_words_count = 0usize;                            
                 unsafe { 
                     data1 = *src1
                 }
                 if len == 1
                 {          
                     let base_addr = 0x0800_0000;
-                    let mut buffer : [u8; 2048] = [0; 2048];
+                    let mut buffer : [u8; 2048] = [0; 2048];// Taken a buffer of one page size 2048
                     let  val = address - base_addr;
                     let  sector = val/0x800;
                     let  offset = (val % 0x800) as usize;
                     let mut addr = (base_addr + (sector * 0x800)) as *mut u8;
                     let mut dst_addr = addr as *mut u16;
                     let temp = addr as u32;
-                    for i in 0..2048
+                    for byte_count in 0..2048
                     {
-                        unsafe { buffer[i]= *addr };
+                        unsafe { buffer[byte_count]= *addr };
                         addr = ((addr as u32) + 1) as *mut u8;
-                        asm::delay(1);
+                        asm::delay(1);              //One clock cycle delay of main clock 
                     }
                     buffer[offset] = data1;
                     self.hal_flash_erase(dst_addr as usize,1);
-                    for i in 0..1024
+                    for half_words in 0..1024
                     { 
                         while self.nvm.sr.read().bsy().bit_is_set() {}
                         if self.nvm.cr.read().lock().bit_is_set() {
@@ -214,7 +182,7 @@ impl FlashInterface for FlashWriterEraser {
                             w
                             .far().bits(temp)
                         });
-                        add = ((buffer[c+1] as u16)<<8 as u16) | buffer[c]  as u16;
+                        add = ((buffer[half_words_count+1] as u16)<<8 as u16) | buffer[half_words_count]  as u16;
                         unsafe{
                             unsafe{*dst_addr = add}
                         } 
@@ -228,7 +196,7 @@ impl FlashInterface for FlashWriterEraser {
                             .pg().clear_bit()
                         });
                         dst_addr = ((dst_addr as u32) + 2) as *mut u16;
-                        c = c + 2;                       
+                        half_words_count = half_words_count + 2;                       
                     }
                     idx = idx +1
                 }
@@ -261,8 +229,8 @@ impl FlashInterface for FlashWriterEraser {
                         w
                         .pg().clear_bit()
                     }); 
-                    src = ((src as u32) + 1) as *mut u16; // increment pointer by 2
-                    dst = ((dst as u32) + 1) as *mut u16; // increment pointer by 2     
+                    src = ((src as u32) + 1) as *mut u16; // increment pointer by 1 byte address
+                    dst = ((dst as u32) + 1) as *mut u16; // increment pointer by 1 byte address
                     idx = idx+1;
                 }
             }

--- a/boards/hal/src/stm/stm32f334.rs
+++ b/boards/hal/src/stm/stm32f334.rs
@@ -20,14 +20,11 @@ mod stm32f334r8_constants {
     pub const UNLOCKKEY1      : u32 = 0x45670123;
     pub const UNLOCKKEY2      : u32 = 0xCDEF89AB;
 
+
 }
-
-
-pub struct FlashWriterEraser {
-    
+pub struct FlashWriterEraser {    
     pub nvm: FLASH,
 }
-
 
 impl FlashWriterEraser {
     pub fn new() -> Self {
@@ -36,7 +33,6 @@ impl FlashWriterEraser {
         }
     }
 }
-
 
 impl FlashInterface for FlashWriterEraser {
 
@@ -51,98 +47,81 @@ impl FlashInterface for FlashWriterEraser {
     ///
     /// Returns:
     /// -  NONE
-
     fn hal_flash_erase(&self, addr: usize, len: usize) {
-        
         let mut flag: bool = true;
         let mut address = (addr & 0x0800_F800) as u32;
-        let r  = len%2048;
-        let mut i = len/2048;
-        if r != 0
+        let remaing_bytes  = len%FLASH_PAGE_SIZE as usize;
+        let mut num_pages = len/FLASH_PAGE_SIZE as usize;
+        if remaing_bytes != 0
         {
-           i = i + 1; 
+           num_pages = num_pages + 1; 
         }
     
-        while i > 0 {
-    
+        while num_pages > 0 {
             match address {
-                        (0x0800_0000..=0x0800_07FF) => flag = true,
-                        (0x0800_0800..=0x0800_0FFF) => flag = true,
-                        (0x0800_1000..=0x0800_17FF) => flag = true,
-                        (0x0800_1800..=0x0800_1FFF) => flag = true,
-                        (0x0800_2000..=0x0800_27FF) => flag = true,
-                        (0x0800_2800..=0x0800_2FFF) => flag = true,
-                        (0x0800_3000..=0x0800_37FF) => flag = true,
-                        (0x0800_3800..=0x0800_3FFF) => flag = true,
-                        (0x0800_4000..=0x0800_47FF) => flag = true,
-                        (0x0800_4800..=0x0800_4FFF) => flag = true,
-                        (0x0800_5000..=0x0800_57FF) => flag = true,
-                        (0x0800_5800..=0x0800_5FFF) => flag = true,
-                        (0x0800_6000..=0x0800_67FF) => flag = true,
-                        (0x0800_6800..=0x0800_6FFF) => flag = true,
-                        (0x0800_7000..=0x0800_77FF) => flag = true,
-                        (0x0800_7800..=0x0800_7FFF) => flag = true,
-                        (0x0800_8000..=0x0800_87FF) => flag = true,
-                        (0x0800_8800..=0x0800_8FFF) => flag = true,
-                        (0x0800_9000..=0x0800_97FF) => flag = true,
-                        (0x0800_9800..=0x0800_9FFF) => flag = true,
-                        (0x0800_A000..=0x0800_A7FF) => flag = true,
-                        (0x0800_A800..=0x0800_AFFF) => flag = true, 
-                        (0x0800_B000..=0x0800_B7FF) => flag = true,
-                        (0x0800_B800..=0x0800_BFFF) => flag = true,
-                        (0x0800_C000..=0x0800_C7FF) => flag = true,
-                        (0x0800_C800..=0x0800_CFFF) => flag = true,
-                        (0x0800_D000..=0x0800_D7FF) => flag = true,
-                        (0x0800_D800..=0x0800_DFFF) => flag = true,
-                        (0x0800_E000..=0x0800_E7FF) => flag = true,
-                        (0x0800_E800..=0x0800_EFFF) => flag = true,
-                        (0x0800_F000..=0x0800_F7FF) => flag = true,
-                        (0x0800_F800..=0x0800_FFFF) => flag = true,
-                        _ => flag = false,
+                (0x0800_0000..=0x0800_07FF) => flag = true,
+                (0x0800_0800..=0x0800_0FFF) => flag = true,
+                (0x0800_1000..=0x0800_17FF) => flag = true,
+                (0x0800_1800..=0x0800_1FFF) => flag = true,
+                (0x0800_2000..=0x0800_27FF) => flag = true,
+                (0x0800_2800..=0x0800_2FFF) => flag = true,
+                (0x0800_3000..=0x0800_37FF) => flag = true,
+                (0x0800_3800..=0x0800_3FFF) => flag = true,
+                (0x0800_4000..=0x0800_47FF) => flag = true,
+                (0x0800_4800..=0x0800_4FFF) => flag = true,
+                (0x0800_5000..=0x0800_57FF) => flag = true,
+                (0x0800_5800..=0x0800_5FFF) => flag = true,
+                (0x0800_6000..=0x0800_67FF) => flag = true,
+                (0x0800_6800..=0x0800_6FFF) => flag = true,
+                (0x0800_7000..=0x0800_77FF) => flag = true,
+                (0x0800_7800..=0x0800_7FFF) => flag = true,
+                (0x0800_8000..=0x0800_87FF) => flag = true,
+                (0x0800_8800..=0x0800_8FFF) => flag = true,
+                (0x0800_9000..=0x0800_97FF) => flag = true,
+                (0x0800_9800..=0x0800_9FFF) => flag = true,
+                (0x0800_A000..=0x0800_A7FF) => flag = true,
+                (0x0800_A800..=0x0800_AFFF) => flag = true, 
+                (0x0800_B000..=0x0800_B7FF) => flag = true,
+                (0x0800_B800..=0x0800_BFFF) => flag = true,
+                (0x0800_C000..=0x0800_C7FF) => flag = true,
+                (0x0800_C800..=0x0800_CFFF) => flag = true,
+                (0x0800_D000..=0x0800_D7FF) => flag = true,
+                (0x0800_D800..=0x0800_DFFF) => flag = true,
+                (0x0800_E000..=0x0800_E7FF) => flag = true,
+                (0x0800_E800..=0x0800_EFFF) => flag = true,
+                (0x0800_F000..=0x0800_F7FF) => flag = true,
+                (0x0800_F800..=0x0800_FFFF) => flag = true,
+                _ => flag = false,
             }
-    
             if flag {
-                        asm::delay(8000_000);
-                        self.hal_flash_unlock();
-                    
-                        while self.nvm.sr.read().bsy().bit_is_set() {}
-            
-                        self.nvm.cr.modify(|_, w| {
-                            w
-                            .per().set_bit() 
-                        });
-                        
-                        self.nvm.ar.write(|w| {
-                            w
-                            .far().bits(address)
-                            });
-            
-                        self.nvm.cr.modify(|_, w| {
-                            w
-                            .strt().set_bit()
-                        });
-            
-                        while self.nvm.sr.read().bsy().bit_is_set() {}
-            
-                        if self.nvm.sr.read().eop().bit_is_set(){
-                        
-                            self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
-                        }
-                    
-                        self.nvm.cr.modify(|_, w| {
-                            w
-                            .per().clear_bit()
-                        });
-                        
-                        self.hal_flash_lock();
-                        asm::delay(8000_000);
-                    }
-    
-            address = address + 2048;
-    
+                self.hal_flash_unlock();
+                while self.nvm.sr.read().bsy().bit_is_set() {}
+                self.nvm.cr.modify(|_, w| {
+                    w
+                    .per().set_bit() 
+                });
+                self.nvm.ar.write(|w| {
+                    w
+                    .far().bits(address)
+                    });
+                self.nvm.cr.modify(|_, w| {
+                    w
+                    .strt().set_bit()
+                });
+                while self.nvm.sr.read().bsy().bit_is_set() {}
+                if self.nvm.sr.read().eop().bit_is_set(){
+                    self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
+                }
+                self.nvm.cr.modify(|_, w| {
+                    w
+                    .per().clear_bit()
+                });
+                self.hal_flash_lock();
+            }
+
+            address = address + FLASH_PAGE_SIZE;
             flag = false;
-            
-            i = i - 1;
+            num_pages = num_pages - 1;
         }
       
     }
@@ -159,189 +138,139 @@ impl FlashInterface for FlashWriterEraser {
     /// -  NONE
     /// 
     fn hal_flash_write(&self, address: usize, data: *const u8, len: usize) {
-        
-        asm::delay(6000);
+
         let address = address as u32;
         let mut len = len as u32;
         let mut idx = 0u32;
         let mut src = data as *mut u16;
         let mut dst = address as *mut u16;
-         
         self.nvm.sr.modify(|_, w| {
             w
              .pgerr().set_bit()
         });
-
         self.hal_flash_unlock();
-
-
         while idx < len {        
-            
-            
             if (len-idx) > 1 {
-                        
-
-                        while self.nvm.sr.read().bsy().bit_is_set() {}
-                      
-                        if self.nvm.cr.read().lock().bit_is_set() {
-
-                            self.hal_flash_unlock();
-                        }
-
-                        self.nvm.cr.modify(|_, w| {
-                            w
-                             .pg().set_bit()
-                        });
-                            
-
-                        unsafe {
-                                     
-                                    write_volatile(dst,*src)
-                        };
-
-                        while self.nvm.sr.read().bsy().bit_is_set(){}
-
-                        if self.nvm.sr.read().eop().bit_is_set(){
-                        
-                            self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
-                        }
-                        self.nvm.cr.modify(|_, w| {
-                            w
-                             .pg().clear_bit()
-                        });
-                        src = ((src as u32) + 2) as *mut u16; // increment pointer by 2
-                        dst = ((dst as u32) + 2) as *mut u16; // increment pointer by 2     
-                        idx =idx+2;
-                    
+                while self.nvm.sr.read().bsy().bit_is_set() {}
+                if self.nvm.cr.read().lock().bit_is_set() {
+                    self.hal_flash_unlock();
+                }
+                self.nvm.cr.modify(|_, w| {
+                    w
+                        .pg().set_bit()
+                });
+                unsafe {             
+                    write_volatile(dst,*src)
+                };
+                while self.nvm.sr.read().bsy().bit_is_set(){}
+                if self.nvm.sr.read().eop().bit_is_set(){
+                    self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
+                }
+                self.nvm.cr.modify(|_, w| {
+                    w
+                    .pg().clear_bit()
+                });
+                src = ((src as u32) + 2) as *mut u16; // increment pointer by 2
+                dst = ((dst as u32) + 2) as *mut u16; // increment pointer by 2     
+                idx =idx+2;      
             }
-            
-          else{  
-
-                            let  src1 = src as *mut u8;
-                            let mut data1 = 0; 
-                            let mut add = 0u16;
-                            let mut c = 0usize;                            
-                            unsafe { data1 = *src1}
-
-                        if len == 1
-                        {          
-
-                                    let base_addr = 0x0800_0000;
-                                    let mut buffer : [u8; 2048] = [0; 2048];
-                                    let  val = address - base_addr;
-
-                                    
-                                    let  sector = val/0x800;
-                                    let  offset = (val % 0x800) as usize;
-                                    let mut addr = (base_addr + (sector * 0x800)) as *mut u8;
-                                    let mut dst_addr = addr as *mut u16;
-                                    let temp = addr as u32;
-
-                                    for i in 0..2048
-                                    {
-                                        unsafe { buffer[i]= *addr };
-                                        addr = ((addr as u32) + 1) as *mut u8;
-                                        asm::delay(1);
-                                    }
-                                    buffer[offset] = data1;
-                                    self.hal_flash_erase(dst_addr as usize,1);
-                                
-                                    for i in 0..1024
-                                    { 
-                                        while self.nvm.sr.read().bsy().bit_is_set() {}
-                        
-                                        if self.nvm.cr.read().lock().bit_is_set() {
-
-                                            self.hal_flash_unlock();
-                                        }
-                                        
-                                        self.nvm.cr.modify(|_, w| {
-                                                w
-                                                .pg().set_bit()
-                                        });
-
-                                        self.nvm.ar.write(|w| {
-                                            w
-                                             .far().bits(temp)
-                                           });
-
-                                        add = ((buffer[c+1] as u16)<<8 as u16) | buffer[c]  as u16;
-
-                                        unsafe{
-                                                
-                                                unsafe{*dst_addr = add}
-                                            } 
-                                         asm::delay(1);
-                                        while self.nvm.sr.read().bsy().bit_is_set() {}
-
-                                        if self.nvm.sr.read().eop().bit_is_set(){
-                                                
-                                                    self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
-                                        }
-                                        self.nvm.cr.modify(|_, w| {
-                                            w
-                                             .pg().clear_bit()
-                                        });
-                                        dst_addr = ((dst_addr as u32) + 2) as *mut u16;
-                                        
-                                        c = c + 2;
-                                        
-                                    }
-                                
-                                idx = idx +1
-                        }
-
-                    else{
-
-                        let mut val = 0u16;
-                        let val_bytes = ((&mut val) as *mut u16) as *mut u8;
-                        let offset = (address + idx) - (((address + idx) >> 1) << 1); // offset from nearest word aligned address
-                        dst = ((dst as u32) - offset) as *mut u16; // subtract offset from dst addr
-                        unsafe {
-                            val = *dst; // assign current val at dst to val
-                                        // store data byte at idx to `val`. `val_bytes` is a byte-pointer to val.
-                        *val_bytes.add(offset as usize) = *data.add(idx as usize);
-                        }
-                        
+            else{  
+                let  src1 = src as *mut u8;
+                let mut data1 = 0; 
+                let mut add = 0u16;
+                let mut c = 0usize;                            
+                unsafe { 
+                    data1 = *src1
+                }
+                if len == 1
+                {          
+                    let base_addr = 0x0800_0000;
+                    let mut buffer : [u8; 2048] = [0; 2048];
+                    let  val = address - base_addr;
+                    let  sector = val/0x800;
+                    let  offset = (val % 0x800) as usize;
+                    let mut addr = (base_addr + (sector * 0x800)) as *mut u8;
+                    let mut dst_addr = addr as *mut u16;
+                    let temp = addr as u32;
+                    for i in 0..2048
+                    {
+                        unsafe { buffer[i]= *addr };
+                        addr = ((addr as u32) + 1) as *mut u8;
+                        asm::delay(1);
+                    }
+                    buffer[offset] = data1;
+                    self.hal_flash_erase(dst_addr as usize,1);
+                    for i in 0..1024
+                    { 
                         while self.nvm.sr.read().bsy().bit_is_set() {}
-                        
                         if self.nvm.cr.read().lock().bit_is_set() {
-
                             self.hal_flash_unlock();
-                        }
-                        
-                        self.nvm.cr.modify(|_, w| {
-                                w
-                                .pg().set_bit()
-                        });
-
-                        unsafe {
-                                    
-                                write_volatile(dst, val);
-                                
-                        };
-
-                        while self.nvm.sr.read().bsy().bit_is_set() {}
-
-                        if self.nvm.sr.read().eop().bit_is_set(){
-                            
-                                self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
                         }
                         self.nvm.cr.modify(|_, w| {
                             w
-                             .pg().clear_bit()
-                        }); 
-                        src = ((src as u32) + 1) as *mut u16; // increment pointer by 2
-                        dst = ((dst as u32) + 1) as *mut u16; // increment pointer by 2     
-                        idx = idx+1;
+                            .pg().set_bit()
+                        });
+                        self.nvm.ar.write(|w| {
+                            w
+                            .far().bits(temp)
+                        });
+                        add = ((buffer[c+1] as u16)<<8 as u16) | buffer[c]  as u16;
+                        unsafe{
+                            unsafe{*dst_addr = add}
+                        } 
+                        asm::delay(1);
+                        while self.nvm.sr.read().bsy().bit_is_set() {}
+                        if self.nvm.sr.read().eop().bit_is_set(){
+                                    self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
+                        }
+                        self.nvm.cr.modify(|_, w| {
+                            w
+                            .pg().clear_bit()
+                        });
+                        dst_addr = ((dst_addr as u32) + 2) as *mut u16;
+                        c = c + 2;                       
                     }
+                    idx = idx +1
+                }
+                else{
+                    let mut val = 0u16;
+                    let val_bytes = ((&mut val) as *mut u16) as *mut u8;
+                    let offset = (address + idx) - (((address + idx) >> 1) << 1); // offset from nearest word aligned address
+                    dst = ((dst as u32) - offset) as *mut u16; // subtract offset from dst addr
+                    unsafe {
+                        val = *dst; // assign current val at dst to val
+                        // store data byte at idx to `val`. `val_bytes` is a byte-pointer to val.
+                        *val_bytes.add(offset as usize) = *data.add(idx as usize);
+                    }
+                    while self.nvm.sr.read().bsy().bit_is_set() {}
+                    if self.nvm.cr.read().lock().bit_is_set() {
+                        self.hal_flash_unlock();
+                    }
+                    self.nvm.cr.modify(|_, w| {
+                        w
+                        .pg().set_bit()
+                    });
+                    unsafe {         
+                        write_volatile(dst, val);    
+                    };
+                    while self.nvm.sr.read().bsy().bit_is_set() {}
+                    if self.nvm.sr.read().eop().bit_is_set(){
+                        self.nvm.sr.modify(|_, w| { w.eop().set_bit()});
+                    }
+                    self.nvm.cr.modify(|_, w| {
+                        w
+                        .pg().clear_bit()
+                    }); 
+                    src = ((src as u32) + 1) as *mut u16; // increment pointer by 2
+                    dst = ((dst as u32) + 1) as *mut u16; // increment pointer by 2     
+                    idx = idx+1;
+                }
             }
         
         }
-
         self.nvm.cr.modify(|_, w| {
             w
-             .pg().clear_bit()
+            .pg().clear_bit()
         });
         self.hal_flash_lock();
     }
@@ -375,9 +304,7 @@ impl FlashInterface for FlashWriterEraser {
 
 }
 
-
 pub fn preboot() {}
-
 struct RefinedUsize<const MIN: u32, const MAX: u32, const VAL: u32>(u32);
 
 impl<const MIN: u32, const MAX: u32, const VAL: u32> RefinedUsize<MIN, MAX, VAL> {
@@ -403,12 +330,12 @@ impl<const MIN: u32, const MAX: u32, const VAL: u32> RefinedUsize<MIN, MAX, VAL>
     }
 }
 
-    /// This method is used to boot the firmware from a particular address
-    ///
-    /// Method arguments:
-    /// -   fw_base_address  : address of the firmware
-    /// Returns:
-    /// -  NONE
+/// This method is used to boot the firmware from a particular address
+///
+/// Method arguments:
+/// -   fw_base_address  : address of the firmware
+/// Returns:
+/// -  NONE
 #[rustfmt::skip]
 pub fn boot_from(fw_base_address: usize) -> ! {
        let address = fw_base_address as u32;
@@ -424,7 +351,5 @@ pub fn boot_from(fw_base_address: usize) -> ! {
        jump_vector();
     
        }
-
        loop{}
 }
-

--- a/rbsigner/src/mcusigner.rs
+++ b/rbsigner/src/mcusigner.rs
@@ -632,4 +632,21 @@ mod tests {
             Err(_e) => {}
         };
     }
+
+    #[test]
+    fn digest_tag_len_test(){
+        let header = McuImageHeader::new_checked([0; 256]);
+        let _val = match header {
+            Ok(mut hdr) => {
+                let _ = hdr.set_digest_tag_len(65540);
+                println!("digest_tag: {:?}", &hdr.inner_ref()[DIGEST_TYPE]);
+                println!("digest_len: {:?}", &hdr.inner_ref()[DIGEST_LEN]);
+                assert_eq!(
+                    &hdr.inner_ref()[DIGEST_TYPE.start..DIGEST_LEN.end],
+                    &[0x00, 0x01, 0x00, 0x04,]
+                );
+            }
+            Err(_e) => {}
+        };
+    }
 }


### PR DESCRIPTION
Test case added for "digest_tag_len" is passed

```
> Executing task: cargo test --package rbsigner --bin rbsigner -- mcusigner::tests::digest_tag_len_test --exact --nocapture <

   Compiling rbsigner v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/rbsigner)
    Finished test [unoptimized + debuginfo] target(s) in 1.45s
     Running unittests src/main.rs (target/debug/deps/rbsigner-788554ad0c9b6684)

running 1 test
test mcusigner::tests::digest_tag_len_test ... digest_tag: [0, 1]
digest_len: [0, 4]
ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


Terminal will be reused by tasks, press any key to close it.
```
 Changes made in "version_tag_len"
```
> Executing task: cargo test --package rbsigner --bin rbsigner -- mcusigner::tests::version_tag_len_test --exact --nocapture <

    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests src/main.rs (target/debug/deps/rbsigner-788554ad0c9b6684)

running 1 test
test mcusigner::tests::version_tag_len_test ... version_tag: [0, 1]
version_len: [4, 0]
ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


Terminal will be reused by tasks, press any key to close it.
```
Xtask is modified and tested

```
sarathk@sarath:~/stm32f/pull_req/rustBoot$ cargo stm32f334 build-sign-flash rustBoot 1234 1235
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/xtask stm32f334 build-sign-flash rustBoot 1234 1235`
$ cargo build --release
   Compiling rustBoot-hal v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/boards/hal)
   Compiling rustBoot-update v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/boards/update)
   Compiling stm32f334_bootfw v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/boards/firmware/stm32f334/boot_fw_blinky_green)
    Finished release [optimized] target(s) in 1.60s
$ cargo build --release
   Compiling stm32f334_updtfw v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/boards/firmware/stm32f334/updt_fw_blinky_red)
    Finished release [optimized] target(s) in 1.17s
$ cargo build --release
   Compiling defmt v0.3.2
   Compiling defmt-macros v0.3.2
   Compiling critical-section v0.2.7
   Compiling defmt-parser v0.3.1
   Compiling bare-metal v1.0.0
   Compiling bitflags v1.3.2
   Compiling defmt-rtt v0.3.2
   Compiling stm32f334 v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/boards/bootloaders/stm32f334)
   Compiling proc-macro-error-attr v1.0.4
   Compiling proc-macro-error v1.0.4
    Finished release [optimized] target(s) in 9.29s
$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f334_bootfw -O binary stm32f334_bootfw.bin
$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f334_updtfw -O binary stm32f334_updtfw.bin
$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f334_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234
   Compiling libc v0.2.126
   Compiling filetime v0.2.17
   Compiling rustBoot v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/rustBoot)
   Compiling rbsigner v0.1.0 (/home/sarathk/stm32f/pull_req/rustBoot/rbsigner)
    Finished dev [unoptimized + debuginfo] target(s) in 3.89s
     Running `/home/sarathk/stm32f/pull_req/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f334_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234`

Update type:    Firmware
Curve type:       nistp256
Input image:      stm32f334_bootfw.bin
Public key:       ecc256.der
Image version:    1234
Output image:     stm32f334_bootfw_v1234_signed.bin
Calculating sha256 digest...
Signing the firmware...
Done.
Output image successfully created with 2508 bytes.

$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f334_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `/home/sarathk/stm32f/pull_req/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f334_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235`

Update type:    Firmware
Curve type:       nistp256
Input image:      stm32f334_updtfw.bin
Public key:       ecc256.der
Image version:    1235
Output image:     stm32f334_updtfw_v1235_signed.bin
Calculating sha256 digest...
Signing the firmware...
Done.
Output image successfully created with 2484 bytes.

$ probe-rs-cli erase --chip stm32f334r8tx
$ probe-rs-cli download --format Bin --base-address 0x800b800 --chip stm32f334r8tx stm32f334_bootfw_v1234_signed.bin
     Erasing sectors ✔ [00:00:01] [################################################################################################]  4.00KiB/ 4.00KiB @  1.81KiB/s (eta 0s )
 Programming pages   ✔ [00:00:02] [################################################################################################]  3.00KiB/ 3.00KiB @     557B/s (eta 0s )
    Finished in 4.483s
$ probe-rs-cli download --format Bin --base-address 0x800d000 --chip stm32f334r8tx stm32f334_updtfw_v1235_signed.bin
     Erasing sectors ✔ [00:00:01] [################################################################################################]  4.00KiB/ 4.00KiB @  1.85KiB/s (eta 0s )
 Programming pages   ✔ [00:00:02] [################################################################################################]  3.00KiB/ 3.00KiB @     554B/s (eta 0s )
    Finished in 4.491s
$ cargo flash --chip stm32f334r8tx --release
    Finished release [optimized] target(s) in 0.08s
    Flashing /home/sarathk/stm32f/pull_req/rustBoot/boards/target/thumbv7em-none-eabihf/release/stm32f334
     Erasing sectors ✔ [00:00:10] [################################################################################################] 44.00KiB/44.00KiB @  4.03KiB/s (eta 0s )
 Programming pages   ✔ [00:00:20] [################################################################################################] 43.00KiB/43.00KiB @  1.31KiB/s (eta 0s )
    Finished in 31.232s
```