### PR TITLE
Added test case for signature tag length.

### DIFF
--- a/rbsigner/src/mcusigner.rs
+++ b/rbsigner/src/mcusigner.rs
@@ -691,4 +691,21 @@ mod tests {
             Err(_e) => {}
         };
     }
+    
+    #[test]
+    fn signature_tag_len_test() {
+        let header = McuImageHeader::new_checked([0; 256]);
+        let _val = match header {
+            Ok(mut hdr) => {
+                let _ = hdr.set_signature_tag_len(65535);
+                println!("signature_tag: {:?}", &hdr.inner_ref()[SIGNATURE_TYPE]);
+                println!("signaure_len: {:?}", &hdr.inner_ref()[SIGNATURE_LEN]);
+                assert_eq!(
+                    &hdr.inner_ref()[SIGNATURE_TYPE.start..SIGNATURE_LEN.end],
+                    &[0x00, 0x00, 0xff, 0xff]
+                );
+            }
+            Err(_e) => {}
+        };
+    }
 }


### PR DESCRIPTION
Tested the mcusigner for stm32f446 board and added est case for the signature tag length.
change log:
1. mcusigner.rs --> added test case for the signature tag length

Test case output
```
   Compiling rbsigner v0.1.0 (/home/anand/Desktop/dev_space/Prod/rustBoot_forked/rbsigner)
    Finished test [unoptimized + debuginfo] target(s) in 0.66s
     Running unittests src/main.rs (target/debug/deps/rbsigner-788554ad0c9b6684)

running 1 test
signature_tag: [0, 0]
signaure_len: [255, 255]
test mcusigner::tests::signature_tag_len_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s
```

single command output for stm32f446
```
anand@anand-VirtualBox:~/Desktop/dev_space/Prod/rustBoot_mcusigner$ cargo stm32f446 build-sign-flash rustBoot 1234 1235
Compiling version_check v0.9.4
   Compiling typenum v1.15.0
   Compiling subtle v2.4.1
   Compiling rand_core v0.6.3
   Compiling const-oid v0.7.1
   Compiling zeroize v1.4.3
   Compiling memchr v2.5.0
   Compiling cfg-if v1.0.0
   Compiling base16ct v0.1.1
   Compiling log v0.4.17
   Compiling opaque-debug v0.3.0
   Compiling cpufeatures v0.2.2
   Compiling anyhow v1.0.58
   Compiling minimal-lexical v0.2.1
   Compiling stable_deref_trait v1.2.0
   Compiling byteorder v1.4.3
   Compiling xshell-macros v0.1.17
   Compiling der v0.5.1
   Compiling ff v0.11.1
   Compiling as-slice v0.2.1
   Compiling group v0.11.0
..
..
Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/xtask stm32f446 build-sign-flash rustBoot 1234 1235`
$ cargo build --release
    Finished release [optimized] target(s) in 0.03s
$ cargo build --release
    Finished release [optimized] target(s) in 0.03s
$ cargo build --release
    Finished release [optimized] target(s) in 0.03s
$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f446_bootfw -O binary stm32f446_bootfw.bin
$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f446_updtfw -O binary stm32f446_updtfw.bin
$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f446_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234
   Compiling libc v0.2.126
   Compiling rustBoot v0.1.0 (/home/anand/Desktop/dev_space/Prod/rustBoot_mcusigner/rustBoot)
   Compiling filetime v0.2.17
   Compiling rbsigner v0.1.0 (/home/anand/Desktop/dev_space/Prod/rustBoot_mcusigner/rbsigner)
    Finished dev [unoptimized + debuginfo] target(s) in 1.18s
     Running `/home/anand/Desktop/dev_space/Prod/rustBoot_mcusigner/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f446_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234`

Update type:    Firmware
Curve type:       nistp256
Input image:      stm32f446_bootfw.bin
Public key:       ecc256.der
Image version:    1234
Output image:     stm32f446_bootfw_v1234_signed.bin
Calculating sha256 digest...
Signing the firmware...
Done.
Output image successfully created with 1948 bytes.

$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f446_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `/home/anand/Desktop/dev_space/Prod/rustBoot_mcusigner/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f446_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235`

Update type:    Firmware
Curve type:       nistp256
Input image:      stm32f446_updtfw.bin
Public key:       ecc256.der
Image version:    1235
Output image:     stm32f446_updtfw_v1235_signed.bin
Calculating sha256 digest...
Signing the firmware...
Done.
Output image successfully created with 2092 bytes.

$ probe-rs-cli erase --chip stm32f446retx
$ probe-rs-cli download --format Bin --base-address 0x8020000 --chip stm32f446retx stm32f446_bootfw_v1234_signed.bin
     Erasing sectors ✔ [00:00:03] [##############################################################################################################] 128.00KiB/128.00KiB @ 37.61KiB/s (eta 0s )
 Programming pages   ✔ [00:00:01] [################################################################################################################]  2.00KiB/ 2.00KiB @     296B/s (eta 0s )
    Finished in 5.804s
$ probe-rs-cli download --format Bin --base-address 0x8040000 --chip stm32f446retx stm32f446_updtfw_v1235_signed.bin
     Erasing sectors ✔ [00:00:03] [##############################################################################################################] 128.00KiB/128.00KiB @ 37.75KiB/s (eta 0s )
 Programming pages   ✔ [00:00:02] [################################################################################################################]  3.00KiB/ 3.00KiB @     353B/s (eta 0s )
    Finished in 6.273s
$ cargo flash --chip stm32f446vetx --release
    Finished release [optimized] target(s) in 0.03s
    Flashing /home/anand/Desktop/dev_space/Prod/rustBoot_mcusigner/boards/target/thumbv7em-none-eabihf/release/stm32f446
     Erasing sectors ✔ [00:00:03] [################################################################################################################] 48.00KiB/48.00KiB @ 11.88KiB/s (eta 0s )
 Programming pages   ✔ [00:00:21] [################################################################################################################] 43.00KiB/43.00KiB @  1.69KiB/s (eta 0s )
    Finished in 25.449s
```
