### PR TITLE
Disable the defmt feature in the BootInSuccessState

### DIFF
--- a/boards/hal/src/rpi/rpi4/panic_wait.rs
+++ b/boards/hal/src/rpi/rpi4/panic_wait.rs
@@ -75,7 +75,7 @@ fn panic(info: &PanicInfo) -> ! {
         location,
         line,
         column,
-        info.message().unwrap_or(&format_args!("")),
+        info.message(),
     );
 
     cpu_core::wait_forever()

--- a/boards/update/src/update/update_flash.rs
+++ b/boards/update/src/update/update_flash.rs
@@ -321,7 +321,7 @@ where
                     {
                         match self.rustboot_update(true) {
                             Err(_v) => {
-                                #[cfg(feature = "defmt")]
+                                // #[cfg(feature = "defmt")]
                                 panic!("all boot options exhausted")
                             } // all boot options exhausted
                             Ok(ref mut img) => {

--- a/boards/update/src/update/update_flash.rs
+++ b/boards/update/src/update/update_flash.rs
@@ -300,7 +300,7 @@ where
                     {
                         match self.rustboot_update(true) {
                             Err(_v) => {
-                                #[cfg(feature = "defmt")]
+                                // #[cfg(feature = "defmt")]
                                 panic!("all boot options exhausted")
                             } // all boot options exhausted
                             Ok(ref mut img) => {


### PR DESCRIPTION
This PR addresses critical issues in rustBoot related to the improper handling of the integrity and authenticity checks, which allowed compromised firmware to run without proper validation

`panic()` Function Behavior: The `panic()` function, intended to halt the system if all boot options are exhausted or an emergency update fails, was not triggering due to a condition related to the `defmt` feature. This allowed execution to continue outside of the match statement, leading to BootInSuccessState being executed each time. This has been resolved, ensuring the system halts as expected when a critical failure occurs, preventing compromised firmware from running.

Fixes: #79